### PR TITLE
:recycle: Fix `clippy::uninlined-format-args`

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -251,7 +251,7 @@ impl Display for EventKind {
             UserGroupAdminAdded,
             UserGroupAdminRemoved
         );
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -255,7 +255,7 @@ mod tests {
     fn request_parser_new() {
         let verification_token = "verification_token";
         let parser = RequestParser::new(verification_token);
-        println!("{:?}", parser);
+        println!("{parser:?}");
     }
 
     #[test]
@@ -264,7 +264,7 @@ mod tests {
         for variant in PARSE_ERROR_VARIANTS.iter() {
             let error = variant.clone();
             assert_eq!(variant, &error);
-            assert_eq!(format!("{:?}", variant), format!("{:?}", error));
+            assert_eq!(format!("{variant:?}"), format!("{error:?}"));
         }
     }
 

--- a/src/payloads/channel.rs
+++ b/src/payloads/channel.rs
@@ -105,8 +105,9 @@ mod tests {
     fn channel_created_test() {
         let data = read_to_string("testdata/channel/channel_created.json").unwrap();
         let payload: ChannelCreatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             ChannelCreatedPayload {
@@ -128,8 +129,9 @@ mod tests {
     fn channel_topic_changed_test() {
         let data = read_to_string("testdata/channel/channel_topic_changed.json").unwrap();
         let payload: ChannelTopicChangedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             ChannelTopicChangedPayload {

--- a/src/payloads/message.rs
+++ b/src/payloads/message.rs
@@ -359,8 +359,9 @@ mod tests {
     fn message_created_test() {
         let data = read_to_string("testdata/message/message_created.json").unwrap();
         let payload: MessageCreatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             MessageCreatedPayload {
@@ -385,8 +386,9 @@ mod tests {
     fn message_deleted_test() {
         let data = read_to_string("testdata/message/message_deleted.json").unwrap();
         let payload: MessageDeletedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             MessageDeletedPayload {
@@ -403,8 +405,9 @@ mod tests {
     fn message_updated_test() {
         let data = read_to_string("testdata/message/message_updated.json").unwrap();
         let payload: MessageUpdatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             MessageUpdatedPayload {
@@ -429,8 +432,9 @@ mod tests {
     fn direct_message_created_test() {
         let data = read_to_string("testdata/message/direct_message_created.json").unwrap();
         let payload: DirectMessageCreatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             DirectMessageCreatedPayload {
@@ -455,8 +459,9 @@ mod tests {
     fn direct_message_deleted_test() {
         let data = read_to_string("testdata/message/direct_message_deleted.json").unwrap();
         let payload: DirectMessageDeletedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             DirectMessageDeletedPayload {
@@ -474,8 +479,9 @@ mod tests {
     fn direct_message_updated_test() {
         let data = read_to_string("testdata/message/direct_message_updated.json").unwrap();
         let payload: DirectMessageUpdatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             DirectMessageUpdatedPayload {
@@ -500,8 +506,9 @@ mod tests {
     fn bot_message_stamps_updated_test() {
         let data = read_to_string("testdata/message/bot_message_stamps_updated.json").unwrap();
         let payload: BotMessageStampsUpdatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             BotMessageStampsUpdatedPayload {

--- a/src/payloads/stamp.rs
+++ b/src/payloads/stamp.rs
@@ -54,8 +54,9 @@ mod tests {
     fn stamp_created_test() {
         let data = read_to_string("testdata/stamp/stamp_created.json").unwrap();
         let payload: StampCreatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             StampCreatedPayload {

--- a/src/payloads/system.rs
+++ b/src/payloads/system.rs
@@ -144,8 +144,9 @@ mod tests {
     fn ping_test() {
         let data = read_to_string("testdata/system/ping.json").unwrap();
         let payload: PingPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             PingPayload {
@@ -158,8 +159,9 @@ mod tests {
     fn joined_test() {
         let data = read_to_string("testdata/system/joined.json").unwrap();
         let payload: JoinedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             JoinedPayload {
@@ -173,8 +175,9 @@ mod tests {
     fn left_test() {
         let data = read_to_string("testdata/system/left.json").unwrap();
         let payload: LeftPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             LeftPayload {

--- a/src/payloads/tag.rs
+++ b/src/payloads/tag.rs
@@ -101,8 +101,9 @@ mod tests {
     fn tag_added_test() {
         let data = read_to_string("testdata/tag/tag_added.json").unwrap();
         let payload: TagAddedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             TagAddedPayload {
@@ -117,8 +118,9 @@ mod tests {
     fn tag_removed_test() {
         let data = read_to_string("testdata/tag/tag_removed.json").unwrap();
         let payload: TagRemovedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             TagRemovedPayload {

--- a/src/payloads/user.rs
+++ b/src/payloads/user.rs
@@ -48,8 +48,9 @@ mod tests {
     fn user_created_test() {
         let data = read_to_string("testdata/user/user_created.json").unwrap();
         let payload: UserCreatedPayload = data.parse().unwrap();
-        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
-        println!("{}", payload);
+        let pretty_payload = serde_json::to_string_pretty(&payload).unwrap();
+        println!("{pretty_payload}");
+        println!("{payload}");
         assert_eq!(
             payload,
             UserCreatedPayload {


### PR DESCRIPTION
close #146 
#143 