### PR TITLE
:recycle: Fix `clippy::module-name-repetitions`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,13 @@ mod parser;
 pub mod payloads;
 
 pub use events::{Event, EventKind};
-pub use parser::{ParseError, RequestParser};
+pub use parser::ParseError;
+
+/// HTTP POSTリクエストのパーサー
+#[derive(Debug, Clone)]
+pub struct RequestParser {
+    verification_token: String,
+}
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use std::{error::Error, fmt, str::from_utf8};
 
 use serde::Deserialize;
 
-use crate::{Event, EventKind};
+use crate::{Event, EventKind, RequestParser};
 
 /// ボディをDeserializeして`Event`に渡す
 fn parse_body<'a, T, F>(f: F, body: &'a str) -> Result<Event, ParseError>
@@ -23,12 +23,6 @@ fn valid_header_value(value: &str) -> bool {
         .as_bytes()
         .iter()
         .all(|c| (0x20..=0x7E).contains(c) || *c == 0x09)
-}
-
-/// HTTP POSTリクエストのパーサー
-#[derive(Debug, Clone)]
-pub struct RequestParser {
-    verification_token: String,
 }
 
 impl RequestParser {

--- a/src/payloads.rs
+++ b/src/payloads.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 //! イベントペイロードの型定義
 
 mod channel;


### PR DESCRIPTION
close #147 
#143 